### PR TITLE
176931989 bug/GitHub login redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   helper_method :get_pending_iteration_feedbacks
   helper_method :get_reviewed_apps
   private
-  @@name_path = nil
+  @@name_path = "/my_projects"
 
   def logged_in?
     @@name_path = request.env['PATH_INFO']

--- a/config/application.yml.asc
+++ b/config/application.yml.asc
@@ -8,3 +8,4 @@ dln4GiFLQdW4GqkZk7CAeizPxAOl3SLeebyqQPjGYsNboGr0FGc0WddNvXVA1lal
 8l6r4Z3qJDiRW2yxvS8ZgIbAr4BSTIuDZKECDlTwr4sRb0qc1LxkjZI=
 =jmxT
 -----END PGP MESSAGE-----
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,7 @@ puts "#{Org.all.size} orgs, #{User.all.size} users"
 coach = User.find_or_create_by(email: 'fox@cs.berekley.edu') do |fox|
 	fox.name = "Armando Fox"
 	fox.github_uid = 'fox'
+	fox.user_type = 'coach'
 end
 cs169 = Org.find_or_create_by(name: 'UCB CS169 Fox') do |ucbcs169|
 	ucbcs169.description = 'CS 169 at UC Berkeley'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,7 @@ puts "#{Org.all.size} orgs, #{User.all.size} users"
 # default coach/coaching org
 coach = User.find_or_create_by(email: 'fox@cs.berekley.edu') do |fox|
 	fox.name = "Armando Fox"
+	fox.github_uid = 'fox'
 end
 cs169 = Org.find_or_create_by(name: 'UCB CS169 Fox') do |ucbcs169|
 	ucbcs169.description = 'CS 169 at UC Berkeley'
@@ -57,4 +58,4 @@ end
 puts "#{App.all.size} apps, #{Engagement.all.size} engagements"
 
 # login mockup
-User.find_or_create_by YAML.load(File.read "#{Rails.root}/db/github_mock_login.yml")["development"]
+User.find_or_create_by(YAML.load(File.read "#{Rails.root}/db/github_mock_login.yml")["development"])


### PR DESCRIPTION
Replicate bug previously:
 First log out and clear cache. This redirect to @@name_path -> nil at very first time. Then we will use session, so can be redirect to the correct page

Solution: 
simple change the private variable @@name_path to main page url (as only situation it will be called is the very first time the user is authorized, should have not secure problem)

Also fixed (possibly need to call "bundle exec rake db:reset" to reset user fox):
- no user called 'fox' when login, add authorized github_id 'fox' when seed 
- Add fox as type coach, so we can have access to everything
