### PR TITLE
[fix] fixed user page to display 'GitHub Username'

### DIFF
--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -14,12 +14,12 @@
     - else
       %li{:class=>'each_page'}
         %a{:class=>"page-link", :href=>"?user_each_page=#{num_per_page}"}=num_per_page
-      
+
 %ul{:class => 'pagination pull-right'}
   - ["First","Previous","Current","Next","Last"].each do |action|
     - if action != "Current" then
       %li{:class=>'page_num'}
-        %a{:class=>"page-link", :href=>"?user_page_action=#{action}&prev=#{@page_num}"}=action 
+        %a{:class=>"page-link", :href=>"?user_page_action=#{action}&prev=#{@page_num}"}=action
     - else
       %li{:class=>"page-num"}
         %a{:class=>'page_link'} Page #{[1,@page_num].max}
@@ -29,7 +29,7 @@
     %tr
       %th Name
       %th Email
-      %th GitHub username
+      %th GitHub Username
       %th Type
       %th SID
       %th

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -17,7 +17,7 @@
             %strong Email:
             = @user.email
           %li
-            %strong Github User ID:
+            %strong GitHub Username:
             = @user.github_uid
           %li
             %strong Preferred Contact:

--- a/features/user_view.feature
+++ b/features/user_view.feature
@@ -32,6 +32,7 @@ Scenario: User view displays the correct names
     Given I am on the Users page
     Then I should see "Joe Deatrick"
     And I should see "Armando Fox"
+		And I should see "GitHub Username"
     And I should not see "Jackson Murphy"
 
 # Story ID: 153070288
@@ -48,6 +49,7 @@ Scenario: The User profile page should have the correct information
     And I should see "2017-11-02"
     And I should see "178"
     And I should see "Armando Fox"
+		And I should see "GitHub Username"
     And I should not see "ACElab"
     And I should not see "Teamscope"
-
+		And I should not see "Github ID"


### PR DESCRIPTION
individual user's page now displays "GitHub Username" instead of "Github ID"
added a few steps in `features/user_view.feature` to test it in cucumber