### PR TITLE
Fixed Checkbox toggle. Clicking outside will not toggle first checkbox.

### DIFF
--- a/app/assets/stylesheets/bootstrap.css
+++ b/app/assets/stylesheets/bootstrap.css
@@ -2666,7 +2666,7 @@ input[type="search"] {
   margin-bottom: 0;
   font-weight: normal;
   vertical-align: middle;
-  cursor: pointer;
+  /*cursor: pointer;*/
 }
 .radio-inline + .radio-inline,
 .checkbox-inline + .checkbox-inline {

--- a/app/views/apps/index.html.haml
+++ b/app/views/apps/index.html.haml
@@ -7,7 +7,7 @@
 - $filters = ""
 #filters
   = form_tag "/", :method => :get do
-    %label.checkbox-inline
+    .checkbox-inline
       %div#deploy
         %strong Deployment Status:
         %em #{" (" + @total_deploy.to_s + ")"}
@@ -22,7 +22,7 @@
           %em (#{@deployment_map[status.to_s].to_i})
           %br
 
-    %label.checkbox-inline
+    .checkbox-inline
       %div#vetting
         %strong Vetting Status:
         %em #{" (" + @total_vet.to_s + ")"}


### PR DESCRIPTION
Previous Problem: Clicking on the text next to checkboxes or within the "container" of the checkboxes will incorrectly toggle the first checkbox.

Solution: The class label was causing issues with its css properties. Removed the label and changed the curser on hover to not be a pointer (this is just for styling since the text is not clickable anyway). 