### PR TITLE
177125007 fix checkbox toggle

### DIFF
--- a/app/assets/stylesheets/bootstrap.css
+++ b/app/assets/stylesheets/bootstrap.css
@@ -2644,7 +2644,7 @@ input[type="search"] {
   padding-left: 20px;
   margin-bottom: 0;
   font-weight: normal;
-  cursor: pointer;
+  /*cursor: pointer;*/
 }
 .radio input[type="radio"],
 .radio-inline input[type="radio"],

--- a/app/assets/stylesheets/bootstrap.css
+++ b/app/assets/stylesheets/bootstrap.css
@@ -2666,7 +2666,7 @@ input[type="search"] {
   margin-bottom: 0;
   font-weight: normal;
   vertical-align: middle;
-  cursor: pointer;
+  /*cursor: pointer;*/
 }
 .radio-inline + .radio-inline,
 .checkbox-inline + .checkbox-inline {

--- a/app/views/apps/index.html.haml
+++ b/app/views/apps/index.html.haml
@@ -7,7 +7,7 @@
 - $filters = ""
 #filters
   = form_tag "/", :method => :get do
-    %label.checkbox-inline
+    .checkbox-inline
       %div#deploy
         %strong Deployment Status:
         %em #{" (" + @total_deploy.to_s + ")"}
@@ -22,7 +22,7 @@
           %em (#{@deployment_map[status.to_s].to_i})
           %br
 
-    %label.checkbox-inline
+    .checkbox-inline
       %div#vetting
         %strong Vetting Status:
         %em #{" (" + @total_vet.to_s + ")"}

--- a/app/views/apps/index.html.haml
+++ b/app/views/apps/index.html.haml
@@ -18,7 +18,8 @@
             = check_box_tag status, 1, true, :class => 'filter'
           - else
             = check_box_tag status, 1, false, :class => 'no_filter'
-          %span{:class => status}= status.to_s.humanize
+          %span{:class => status}
+            = label_tag status
           %em (#{@deployment_map[status.to_s].to_i})
           %br
 
@@ -33,7 +34,8 @@
             = check_box_tag status, 1, true, :class => 'filter'
           - else
             = check_box_tag status, 1, false, :class => 'no_filter'
-          %span{:class => status}= status.to_s.humanize
+          %span{:class => status}
+            = label_tag status
           %em (#{@vetting_map[status.to_s].to_i})
           %br
         %br


### PR DESCRIPTION
Problem: The first checkbox would be incorrectly toggled whenever the user clicks on the text next to the checkboxes or within the "container" of the filters.

Solution: There was an issue with the class label settings. Removing the class label and providing each checkbox with its own label fixed the toggling issue. I also changed the cursor because it changed into a pointer at odd times (not on a checkbox or text).